### PR TITLE
Bugfix/cp 3699 move page field under source

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `states`                    | No       | `["OPEN", "MERGED"]`             | The PR states to select (`OPEN`, `MERGED` or `CLOSED`). The pipeline will only trigger on pull requests matching one of the specified states. Default is ["OPEN"].                                                                                                                         |
 | `status_context`            | No       | `concourse-ci/build`             | Filter out PRs that contain the status context on their latest SHA |
 | `verbose`                   | No       | `true`                           | Show more information during `check` about PR filtering |
+| `page`                      | No       | `{ max_prs: 300, page_size: 50 }`| GitHub API query configuration - check [Page Configuration](#page-configuration) |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).
@@ -49,11 +50,11 @@ Notes:
 ## Page Configuration
 | Parameter                     | Required   | Example                            | Description                                                                                                                                                                                                                                                                                  |
 | ----------------------------- | ---------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sort_field`                  | No         | `UPDATED_AT`                       | Github field to sort by. One of 'UPDATED_AT', 'CREATED_AT', 'COMMENTS'. Default value 'UPDATED_AT'
+| `sort_field`                  | No         | `UPDATED_AT`                       | GitHub field to sort by. One of 'UPDATED_AT', 'CREATED_AT', 'COMMENTS'. Default value 'UPDATED_AT'
 | `sort_direction`              | No         | `ASC`                              | Whether to sort in ascending or descending order. E.g. 'ASC' for 'CREATED_AT' field will start with the oldest pull request. Default value 'DESC'
 | `max_prs`                     | No         | `250`                              | Maximum number of pull requests to fetch. Max value 2000, default value 200
-| `page_size`                   | No         | `25`                               | Number of pull requests to fetch on one page, a higher number runs a greater risk of causing Github API to timeout. Max value 100, default value 50
-| `delay_between_pages`         | No         | `2000`                             | Number of milliseconds between each page request to the Github API. A higher number runs a greater risk of causing Github API to timeout. Default value 500
+| `page_size`                   | No         | `25`                               | Number of pull requests to fetch on one page, a higher number runs a greater risk of causing GitHub API to timeout. Max value 100, default value 50
+| `delay_between_pages`         | No         | `2000`                             | Number of milliseconds between each page request to the GitHub API. A higher number runs a greater risk of causing GitHub API to timeout. Default value 500
 | `max_retries`                 | No         | `3`                                | Number of times to re-attempt the API request if it fails. Default value 4
 
 ## Behaviour

--- a/check.go
+++ b/check.go
@@ -14,7 +14,7 @@ import (
 
 func LogSkipped(p *PullRequest, name string, additional []string) {
 	PrintLog(fmt.Sprintf("%d skipped, reason: %s", p.Number, name))
-	
+
 	for _, a := range additional {
 		PrintLog(a)
 	}
@@ -36,7 +36,7 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 		filterStates = request.Source.States
 	}
 
-	pulls, err := manager.ListPullRequests(filterStates, request.Page)
+	pulls, err := manager.ListPullRequests(filterStates, request.Source.Page)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last commits: %s", err)
@@ -61,7 +61,7 @@ Loop:
 
 		// [ci skip]/[skip ci] in Commit message
 		if !disableSkipCI && ContainsSkipCI(p.Tip.Message) {
-			LogSkipped(p, "ci skip]/[skip ci] in Commit message",[]string{
+			LogSkipped(p, "ci skip]/[skip ci] in Commit message", []string{
 				fmt.Sprint("disableSkipCI:", disableSkipCI),
 				fmt.Sprint("p.Tip.Message:", p.Tip.Message)})
 			continue
@@ -88,7 +88,7 @@ Loop:
 		// Filter out commits that already have a build status
 		if request.Source.StatusContext != "" && p.HasStatus {
 			LogSkipped(p, "Filter out commits that already have a build status", []string{
-				fmt.Sprint("request.Source.StatusContext:", request.Source.StatusContext), 
+				fmt.Sprint("request.Source.StatusContext:", request.Source.StatusContext),
 				fmt.Sprint("p.HasStatus:", p.HasStatus)})
 			continue
 		}
@@ -134,7 +134,7 @@ Loop:
 		// Filter pull request if it does not have the required number of approved review(s).
 		if p.ApprovedReviewCount < request.Source.RequiredReviewApprovals {
 			LogSkipped(p, "Filter pull request if it does not have the required number of approved review(s).", []string{
-				fmt.Sprint("p.ApprovedReviewCount:", p.ApprovedReviewCount ),
+				fmt.Sprint("p.ApprovedReviewCount:", p.ApprovedReviewCount),
 				fmt.Sprint("request.Source.RequiredReviewApprovals:", request.Source.RequiredReviewApprovals)})
 			continue
 		}
@@ -264,9 +264,8 @@ func IsInsidePath(parent, child string) bool {
 
 // CheckRequest ...
 type CheckRequest struct {
-	Source     Source     `json:"source"`
-	Version    Version    `json:"version"`
-	Page       Page       `json:"page"`
+	Source  Source  `json:"source"`
+	Version Version `json:"version"`
 }
 
 // CheckResponse ...

--- a/development.md
+++ b/development.md
@@ -46,15 +46,15 @@ to add optional parameters to your query:
     "source": {
         "repository": "<<repository_name>>",
         "access_token": "<<place_your_github_pat_here>>",
-        "status_context": "concourse-ci/status"
-    },
-    "page": {
-        "sort_field": "UPDATED_AT",
-        "sort_direction": "ASC",
-        "max_prs": 600,
-        "page_size": 25,
-        "delay_between_pages": 1000,
-        "max_retries": 3
+        "status_context": "concourse-ci/status",
+        "page": {
+            "sort_field": "UPDATED_AT",
+            "sort_direction": "ASC",
+            "max_prs": 200,
+            "page_size": 50,
+            "delay_between_pages": 100,
+            "max_retries": 3
+        }
     }
 }
 ```

--- a/github.go
+++ b/github.go
@@ -158,7 +158,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState, p 
 
 	log.Printf("Sorting PRs by %s in %s order", p.SortField, p.SortDirection)
 	log.Printf("Retrieving %d PRs (%d per page)", p.MaxPRs, p.PageSize)
-	log.Printf("Will wait %dms between pages and retry failures upto %d times", p.DelayBetweenPages, p.MaxRetries)
+	log.Printf("Will wait %dms between pages and retry failures up to %d times", p.DelayBetweenPages, p.MaxRetries)
 	maxPages := p.MaxPRs / p.PageSize
 
 	page := 0

--- a/github.go
+++ b/github.go
@@ -156,7 +156,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState, p 
 
 	var response []*PullRequest
 
-	log.Printf("Sorting PRs by %s in %s order",  p.SortField, p.SortDirection)
+	log.Printf("Sorting PRs by %s in %s order", p.SortField, p.SortDirection)
 	log.Printf("Retrieving %d PRs (%d per page)", p.MaxPRs, p.PageSize)
 	log.Printf("Will wait %dms between pages and retry failures upto %d times", p.DelayBetweenPages, p.MaxRetries)
 	maxPages := p.MaxPRs / p.PageSize


### PR DESCRIPTION
concourse accepts only certain set of input fields for resource:
[Resources - Concourse CI](https://concourse-ci.org/resources.html#schema.resource) 
we cannot add new field Page - it needs to be under Source
we have to move Page field and adjust tests

https://chillibean.atlassian.net/browse/CP-3699