### PR TITLE
task/DEVX-174 Added logic to filter out pull requests without required check runs passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `status_context`            | No       | `concourse-ci/build`             | Filter out PRs that contain the status context on their latest SHA |
 | `verbose`                   | No       | `true`                           | Show more information during `check` about PR filtering |
 | `page`                      | No       | `{ max_prs: 300, page_size: 50 }`| GitHub API query configuration - check [Page Configuration](#page-configuration) |
+| `required_check_runs`       | No       | `["lint", "jest"]`               | Filter out PRs that do not have those check runs passing |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).

--- a/development.md
+++ b/development.md
@@ -36,7 +36,7 @@ example
         "access_token": "<<place_your_github_pat_here>>",
         "status_context": "concourse-ci/status",
         "states": ["OPEN","MERGED"]
-    } 
+    }
 }
 ```
 

--- a/github.go
+++ b/github.go
@@ -118,7 +118,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState, p 
 								Node struct {
 									Commit struct {
 										CommitObject
-										Status StatusObject
+										Status            StatusObject
 										StatusCheckRollup struct {
 											Contexts struct {
 												Nodes []StatusCheckRollupContextObject

--- a/in_test.go
+++ b/in_test.go
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 				State:               githubv4.PullRequestStateOpen,
 			},
 			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
 		},
@@ -61,7 +61,7 @@ func TestGet(t *testing.T) {
 				State:               githubv4.PullRequestStateOpen,
 			},
 			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
 		},
@@ -81,7 +81,7 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "rebase",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
 		},
@@ -101,7 +101,7 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "checkout",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
 		},
@@ -121,7 +121,7 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				GitDepth: 2,
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:    createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z","approved_review_count":"0","state":"OPEN"}`,
 			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"state","value":"OPEN"}]`,
 		},
@@ -141,7 +141,7 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				ListChangedFiles: true,
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 			files: []resource.ChangedFileObject{
 				{
 					Path: "README.md",
@@ -328,6 +328,7 @@ func createTestPR(
 	isDraft bool,
 	state githubv4.PullRequestState,
 	hasStatus bool,
+	checkRuns map[string]string,
 ) *resource.PullRequest {
 	n := strconv.Itoa(count)
 	d := time.Now().AddDate(0, 0, -count)
@@ -381,6 +382,7 @@ func createTestPR(
 		ApprovedReviewCount: approvedCount,
 		Labels:              labelObjects,
 		HasStatus:           hasStatus,
+		CheckRuns:           checkRuns,
 	}
 }
 

--- a/models.go
+++ b/models.go
@@ -31,6 +31,7 @@ type Source struct {
 	StatusContext           string                      `json:"status_context"`
 	Page                    Page                        `json:"page"`
 	Verbose                 bool                        `json:"verbose"`
+	RequiredCheckRuns       []string                    `json:"required_check_runs"`
 }
 
 // Validate the source configuration.
@@ -107,6 +108,7 @@ type PullRequest struct {
 	ApprovedReviewCount int
 	Labels              []LabelObject
 	HasStatus           bool
+	CheckRuns           map[string]string
 }
 
 // PullRequestObject represents the GraphQL commit node.
@@ -174,6 +176,19 @@ type ChangedFileObject struct {
 // https://developer.github.com/v4/object/label
 type LabelObject struct {
 	Name string
+}
+
+// StatusCheckRollupContextObject represents the GraphQL StatusCheckRollupContext union node.
+// https://developer.github.com/v4/union/statuscheckrollupcontext
+type StatusCheckRollupContextObject struct {
+	CheckRunObject `graphql:"... on CheckRun"`
+}
+
+// CheckRunObject represents the GraphQL CheckRun node.
+// https://developer.github.com/v4/object/checkrun
+type CheckRunObject struct {
+	Conclusion string
+	Name       string
 }
 
 // Page represents settings for request parameters

--- a/out_test.go
+++ b/out_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPut(t *testing.T) {
-
 	tests := []struct {
 		description string
 		source      resource.Source
@@ -34,7 +33,7 @@ func TestPut(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters:  resource.PutParameters{},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -51,7 +50,7 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				Status: "success",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -69,7 +68,7 @@ func TestPut(t *testing.T) {
 				Status:  "failure",
 				Context: "build",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -88,7 +87,7 @@ func TestPut(t *testing.T) {
 				BaseContext: "concourse-ci-custom",
 				Context:     "build",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -106,7 +105,7 @@ func TestPut(t *testing.T) {
 				Status:    "failure",
 				TargetURL: "https://targeturl.com/concourse",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -124,7 +123,7 @@ func TestPut(t *testing.T) {
 				Status:      "failure",
 				Description: "Concourse CI build",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -141,7 +140,7 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				Comment: "comment",
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -158,7 +157,7 @@ func TestPut(t *testing.T) {
 			parameters: resource.PutParameters{
 				DeletePreviousComments: true,
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, []string{}, false, githubv4.PullRequestStateOpen, false),
+			pullRequest: createTestPR(1, "master", false, false, 0, []string{}, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 	}
 
@@ -251,7 +250,7 @@ func TestVariableSubstitution(t *testing.T) {
 				Comment: fmt.Sprintf("$%s", variableName),
 			},
 			expectedComment: variableValue,
-			pullRequest:     createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:     createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -270,7 +269,7 @@ func TestVariableSubstitution(t *testing.T) {
 				TargetURL: fmt.Sprintf("%s$%s", variableURL, variableName),
 			},
 			expectedTargetURL: fmt.Sprintf("%s%s", variableURL, variableValue),
-			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:       createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 
 		{
@@ -288,7 +287,7 @@ func TestVariableSubstitution(t *testing.T) {
 				Comment: "$THIS_IS_NOT_SUBSTITUTED",
 			},
 			expectedComment: "$THIS_IS_NOT_SUBSTITUTED",
-			pullRequest:     createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false),
+			pullRequest:     createTestPR(1, "master", false, false, 0, nil, false, githubv4.PullRequestStateOpen, false, nil),
 		},
 	}
 

--- a/out_test.go
+++ b/out_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestPut(t *testing.T) {
+
 	tests := []struct {
 		description string
 		source      resource.Source


### PR DESCRIPTION
Example:
```json
{
    "source": {
        "repository": "Chillibean/<<repo_name>>",
        "access_token": "<<PAT>>",
        "status_context": "concourse-ci/status",
        "states": ["OPEN","MERGED"],
        "verbose": true,
        "required_check_runs": ["lint", "jest"]
    }
}
```