### PR TITLE
Fix/DEVEX 237 caching of GitHub actions results

### DIFF
--- a/github.go
+++ b/github.go
@@ -157,7 +157,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState, p 
 		"commitsLast":       githubv4.Int(1),
 		"prReviewStates":    []githubv4.PullRequestReviewState{githubv4.PullRequestReviewStateApproved},
 		"labelsFirst":       githubv4.Int(10),
-		"contextsFirst":     githubv4.Int(10),
+		"contextsFirst":     githubv4.Int(100),
 	}
 
 	var response []*PullRequest

--- a/models.go
+++ b/models.go
@@ -189,6 +189,7 @@ type StatusCheckRollupContextObject struct {
 type CheckRunObject struct {
 	Conclusion string
 	Name       string
+	CompletedAt string
 }
 
 // Page represents settings for request parameters


### PR DESCRIPTION
Seems like results of github actions are being cached (or are not correct) on concourse side and PRs chosen for building are incorrectly filtered out.

https://chillibean.atlassian.net/browse/DEVEX-237